### PR TITLE
add basic menu navigation and remove concept of treasure from GameTurn

### DIFF
--- a/lib/studio_game/action.rb
+++ b/lib/studio_game/action.rb
@@ -7,7 +7,16 @@ module StudioGame
         Action.new(:attack, 1),
         Action.new(:heal, 2),
         Action.new(:flee, 3),
-        Action.new("access last menu", 4),
+      ]
+
+      ATTACK_OPTIONS = [
+        Action.new(:confirm, 1),
+        Action.new("access last menu", 4)
+      ]
+
+      HEAL_OPTIONS = [
+        Action.new(:confirm, 1),
+        Action.new("access last menu", 4)
       ]
     end
   end

--- a/lib/studio_game/action_interpreter.rb
+++ b/lib/studio_game/action_interpreter.rb
@@ -1,0 +1,28 @@
+require_relative 'die'
+require_relative 'player'
+require_relative 'treasure_trove'
+require_relative 'action_selector'
+require_relative 'action'
+require_relative 'game_turn'
+
+module StudioGame
+  class ActionInterpreter
+    def interpret_action_input(input, player)
+      case input
+      when 1
+        player.blam
+      when 4
+        GameTurn.take_turn(player)
+      end
+    end
+
+    def interpret_heal_input(input, player)
+      case input
+      when 1
+        player.w00t
+      when 4
+        GameTurn.take_turn(player)
+      end
+    end
+  end
+end

--- a/lib/studio_game/action_selector.rb
+++ b/lib/studio_game/action_selector.rb
@@ -8,8 +8,8 @@ module StudioGame
       action = gets.chomp.to_i
     end
 
-    def print_options
-      StudioGame::ActionChooser::OPTIONS.each do |option|
+    def print_options(options=StudioGame::ActionChooser::OPTIONS)
+      options.each do |option|
         puts "Press #{option.select} to #{option.name}"          
       end
     end

--- a/lib/studio_game/game_turn.rb
+++ b/lib/studio_game/game_turn.rb
@@ -3,23 +3,26 @@ require_relative 'player'
 require_relative 'treasure_trove'
 require_relative 'action_selector'
 require_relative 'action'
+require_relative 'action_interpreter'
 
 module StudioGame
   module GameTurn
     def self.take_turn(player)
       encounter = ActionSelector.new
       t = StudioGame::TreasureTrove.random
+      i = ActionInterpreter.new
       encounter.print_options
       input = encounter.get_input
       case input
       when 1
-        player.blam
+        encounter.print_options(StudioGame::ActionChooser::ATTACK_OPTIONS)
+        i.interpret_action_input(encounter.get_input, player)
       when 2
-        player.w00t
+        encounter.print_options(StudioGame::ActionChooser::HEAL_OPTIONS)
+        i.interpret_heal_input(encounter.get_input, player)
       else
-        puts "#{player.name} was skipped."
+        puts "#{player.name} fled."
       end
-      player.found_treasure(t)
     end
   end
 end

--- a/spec/studio_game/game_spec.rb
+++ b/spec/studio_game/game_spec.rb
@@ -18,32 +18,32 @@ module StudioGame
       expect(@game.players.count).to eq(1)
     end
 
-    it "assigns a treasure for points during a player's turn" do
-      game = Game.new("Knuckleheads")
-      player = Player.new("moe")
-      game.add_player(player)
-      game.play(1)
-      
-      expect(player.points).not_to be_zero
-    end
-    
-    it "w00ts the player if a high number is rolled" do
-      allow_any_instance_of(Die).to receive(:roll).and_return(5)
-      @game.play(1)
-      expect(@player.health).to eq(@initial_health + 15)
-    end
-    
-    it "skips the player if a medium number is rolled" do
-      allow_any_instance_of(Die).to receive(:roll).and_return(3)
-      @game.play(1)
-      expect(@player.health).to eq(@initial_health)
-    end
-    
-    it "blams the player if a low number is rolled" do
-      allow_any_instance_of(Die).to receive(:roll).and_return(1)
-      @game.play(1)
-      expect(@player.health).to eq(@initial_health - 10)
-    end
+#    it "assigns a treasure for points during a player's turn" do
+#      game = Game.new("Knuckleheads")
+#      player = Player.new("moe")
+#      game.add_player(player)
+#      game.play(1)
+#      
+#      expect(player.points).not_to be_zero
+#    end
+#    
+#    it "w00ts the player if a high number is rolled" do
+#      allow_any_instance_of(Die).to receive(:roll).and_return(5)
+#      @game.play(1)
+#      expect(@player.health).to eq(@initial_health + 15)
+#    end
+#    
+#    it "skips the player if a medium number is rolled" do
+#      allow_any_instance_of(Die).to receive(:roll).and_return(3)
+#      @game.play(1)
+#      expect(@player.health).to eq(@initial_health)
+#    end
+#    
+#    it "blams the player if a low number is rolled" do
+#      allow_any_instance_of(Die).to receive(:roll).and_return(1)
+#      @game.play(1)
+#      expect(@player.health).to eq(@initial_health - 10)
+#    end
 
     it "computes total points as the sum of all player points" do
       game = Game.new("Knuckleheads")


### PR DESCRIPTION
<img width="383" alt="screen shot 2016-03-18 at 5 11 32 pm" src="https://cloud.githubusercontent.com/assets/10456489/13895099/7e308ade-ed2c-11e5-881c-c898419f5a29.png">
<img width="356" alt="screen shot 2016-03-18 at 5 11 12 pm" src="https://cloud.githubusercontent.com/assets/10456489/13895100/7e440b22-ed2c-11e5-8b32-09c2140c8894.png">
<img width="357" alt="screen shot 2016-03-18 at 5 10 49 pm" src="https://cloud.githubusercontent.com/assets/10456489/13895101/7e5550d0-ed2c-11e5-94a8-1d26e8836b1a.png">
